### PR TITLE
Fix compilation for OpenSSL 1.1.0

### DIFF
--- a/plugin/mecevp.cpp
+++ b/plugin/mecevp.cpp
@@ -271,10 +271,7 @@ soap_mec_init(struct soap *soap, struct soap_mec_data *data, int alg, SOAP_MEC_K
 { int ok = 1;
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_mec_init()\n"));
   soap_ssl_init();
-  data->ctx = (EVP_CIPHER_CTX*)SOAP_MALLOC(soap, sizeof(EVP_CIPHER_CTX));
-  if (!data->ctx)
-    return soap->error = SOAP_EOM;
-  EVP_CIPHER_CTX_init(data->ctx);
+  data->ctx = EVP_CIPHER_CTX_new();
   data->alg = alg;
   data->state = SOAP_MEC_STATE_NONE;
   if (alg & SOAP_MEC_DES_CBC)
@@ -392,7 +389,7 @@ void
 soap_mec_cleanup(struct soap *soap, struct soap_mec_data *data)
 { DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_mec_cleanup()\n"));
   if (data->ctx)
-  { EVP_CIPHER_CTX_cleanup(data->ctx);
+  { EVP_CIPHER_CTX_free(data->ctx);
     SOAP_FREE(soap, data->ctx);
     data->ctx = NULL;
   }

--- a/stdsoap2.cpp
+++ b/stdsoap2.cpp
@@ -53,6 +53,10 @@ A commercial use license is available from Genivia, Inc., contact@genivia.com
 
 #define GSOAP_LIB_VERSION 20817
 
+#ifndef M_ASN1_STRING_data
+#define M_ASN1_STRING_data(x)	((x)->data)
+#endif
+
 #ifdef AS400
 # pragma convert(819)	/* EBCDIC to ASCII */
 #endif


### PR DESCRIPTION
Since OpenSSL 1.0.x is now considered legacy, some updates should be made so the project compiles against the current stable version 1.1.0. To this end, this PR replaces `XXX_CTX_init` and `XXX_CTX_cleanup` with the new API `XXX_CTX_new` and `XXX_CTX_free`.
